### PR TITLE
2 account no tiene estado habilitado deshabilitado

### DIFF
--- a/src/main/kotlin/wallet/Account.kt
+++ b/src/main/kotlin/wallet/Account.kt
@@ -17,22 +17,18 @@ class Account(val user: User, val cvu: String) {
         state.addTransaction(this, transaction)
     }
 
-    private fun setState(state: Accountable) {
-        this.state = state
+    fun block() {
+        state = BlockedState()
+        isBlocked = true
     }
 
-    fun setBlocked() {
-        this.state = BlockedState()
-        this.isBlocked = true
-    }
-
-    fun setUnblocked() {
-        this.state = UnblockedState()
-        this.isBlocked = false
+    fun unblock() {
+        state = UnblockedState()
+        isBlocked = false
     }
 
     fun addLoyalty(loyaltyGift: LoyaltyGift) {
-        this.state.addLoyalty(this, loyaltyGift)
+        state.addLoyalty(this, loyaltyGift)
     }
 
     fun isLoyaltyApplied(loyaltyGift: LoyaltyGift): Boolean {
@@ -57,12 +53,10 @@ class UnblockedState: Accountable {
 
 class BlockedState: Accountable {
     override fun addTransaction(account: Account, transaction: Transactional) {
-        val cvu = account.cvu
-        throw BlockedAccountException("Account with cvu ${cvu} is blocked and unable to perform operations")
+        throw BlockedAccountException("Account with cvu ${account.cvu} is blocked and unable to perform operations")
     }
 
     override fun addLoyalty(account: Account, loyaltyGift: LoyaltyGift) {
-        val cvu = account.cvu
-        throw BlockedAccountException("Account with cvu ${cvu} is blocked and unable to accept any loyalty")
+        throw BlockedAccountException("Account with cvu ${account.cvu} is blocked and unable to accept any loyalty")
     }
 }

--- a/src/main/kotlin/wallet/DigitalWallet.kt
+++ b/src/main/kotlin/wallet/DigitalWallet.kt
@@ -45,11 +45,11 @@ class DigitalWallet {
     }
 
     fun blockAccount(account: Account) {
-        this.accountByCVU(account.cvu).setBlocked()
+        this.accountByCVU(account.cvu).block()
     }
 
     fun unblockAccount(account: Account) {
-        this.accountByCVU(account.cvu).setUnblocked()
+        this.accountByCVU(account.cvu).unblock()
     }
 
     fun getAllAdmins() = this.users.filter { it.isAdmin }

--- a/src/main/kotlin/wallet/DigitalWallet.kt
+++ b/src/main/kotlin/wallet/DigitalWallet.kt
@@ -44,6 +44,14 @@ class DigitalWallet {
         this.users.remove(user)
     }
 
+    fun blockAccount(account: Account) {
+        this.accountByCVU(account.cvu).setBlocked()
+    }
+
+    fun unblockAccount(account: Account) {
+        this.accountByCVU(account.cvu).setUnblocked()
+    }
+
     fun getAllAdmins() = this.users.filter { it.isAdmin }
 
     fun transfer(fromCVU : String, toCVU: String, amount: Double) {
@@ -56,6 +64,7 @@ class DigitalWallet {
     fun transferMoneyFromCard(fromCVU: String, card: Card, amount: Double) {
         val account = accountByCVU(fromCVU)
         assertExistsUser(account.user)
+        assertAccountUnblocked(account)
         account.addTransaction(CashInWithCard(now(), amount, card, account))
     }
 
@@ -71,6 +80,7 @@ class DigitalWallet {
 
     fun addGift(gift: InitialGift) {
         assertExistsAccount(gift.to)
+        assertAccountUnblocked(gift.to)
         accounts.first { it.cvu == gift.to.cvu }.addTransaction(gift)
     }
 
@@ -83,6 +93,12 @@ class DigitalWallet {
         assert(accounts.any {
             it.cvu == account.cvu && it.user.idCard == account.user.idCard
         }) { "Account doesn't exists or it belongs to another user" }
+    }
+
+    private fun assertAccountUnblocked(account: Account) {
+        assert(!account.isBlocked) {
+            throw BlockedAccountException("Account with ${account.cvu} is Blocked")
+        }
     }
 
     private fun assertAccountWithoutFund(account: Account?) {
@@ -100,6 +116,11 @@ class DigitalWallet {
         assertExistsAccount(cashIn.to)
         assert(cashIn.from == cashOut.from) { "Account ${cashIn.from.cvu} is inconsistent" }
         assert(cashIn.to == cashOut.to) { "Account ${cashIn.to.cvu} is inconsistent" }
+        assertAccountUnblocked(cashIn.from)
+        assertAccountUnblocked(cashIn.to)
+        assert(!cashIn.to.isBlocked) {
+            throw BlockedAccountException("Account with ${cashIn.from.cvu} is Blocked")
+        }
         assert(cashOut.from.balance >= cashIn.amount) {
             throw NoMoneyException("Account ${cashOut.from} have no enough money to make this transfer")
         }

--- a/src/main/kotlin/wallet/Exceptions.kt
+++ b/src/main/kotlin/wallet/Exceptions.kt
@@ -2,3 +2,4 @@ package wallet
 
 class NoMoneyException(message: String?) : Throwable(message)
 class LoginException(message: String?) : Throwable(message)
+class BlockedAccountException(message: String?) : Throwable(message)

--- a/src/test/kotlin/support/Builders.kt
+++ b/src/test/kotlin/support/Builders.kt
@@ -1,7 +1,6 @@
 package support
 
-import wallet.Account
-import wallet.User
+import wallet.*
 
 class UserBuilder() {
     private var idCard: String = "000"
@@ -31,6 +30,23 @@ class UserBuilder() {
 
     fun isAdmin(value: Boolean) : UserBuilder {
         isAdmin = value
+        return this
+    }
+}
+
+class AccountBuilder() {
+    var user: User = UserBuilder().build()
+    var cvu: String = "12345678-12345678910121"
+
+    fun build(): Account = Account(user, cvu)
+
+    fun user(value: User): AccountBuilder {
+        user = value
+        return this
+    }
+
+    fun cvu(value: String): AccountBuilder {
+        cvu = value
         return this
     }
 }

--- a/src/test/kotlin/wallet/AccountSpec.kt
+++ b/src/test/kotlin/wallet/AccountSpec.kt
@@ -1,0 +1,2 @@
+package wallet
+

--- a/src/test/kotlin/wallet/AccountSpec.kt
+++ b/src/test/kotlin/wallet/AccountSpec.kt
@@ -1,2 +1,88 @@
 package wallet
 
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import support.AccountBuilder
+import support.UserBuilder
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+object AccountSpec : Spek({
+    describe("Account") {
+        val cvu by memoized { DigitalWallet.generateNewCVU() }
+        val aUser by memoized { UserBuilder().idCard("11.222.333").build() }
+        val to by memoized { AccountBuilder().user(aUser).cvu(cvu).build() }
+
+        it("should have an empty balance on creation") {
+            assertEquals(0.0, to.balance)
+        }
+
+        it("should have no transactions on creation") {
+            assertEquals(0, to.transactions.size)
+        }
+
+        it("should have no applied loyalties on creation") {
+            assertEquals(0, to.appliedLoyalties.size)
+        }
+
+        it("should be able to operate on an Unblocked state") {
+            val amount = 200.0
+            val anotherUser = UserBuilder().idCard("22.333.444").build()
+            val from = AccountBuilder().user(anotherUser).build()
+            val cashInTransfer = CashInTransfer(LocalDateTime.now(), amount, from, to )
+
+            to.setUnblocked()
+            to.addTransaction(cashInTransfer)
+
+            assert(!to.isBlocked)
+            assertEquals(amount, to.balance)
+        }
+
+        it("should not be able to operate on a Blocked state") {
+            val amount = 200.0
+            val anotherUser = UserBuilder().idCard("22.333.444").build()
+            val from = AccountBuilder().user(anotherUser).build()
+            val cashInTransfer = CashInTransfer(LocalDateTime.now(), amount, from, to )
+
+            to.setBlocked()
+
+            assert(to.isBlocked)
+            assertThrows<BlockedAccountException> { to.addTransaction(cashInTransfer) }
+        }
+
+        it("should be able to receive loyalties on an Unblocked state") {
+            val cashInLoyalty = LoyaltyGift(
+                "Discount Loyalty",
+                DiscountGiftStrategy(10),
+                10,
+                100,
+                LocalDate.now(),
+                LocalDate.MAX
+            )
+
+            to.setUnblocked()
+            to.addLoyalty(cashInLoyalty)
+
+            assert(!to.isBlocked)
+            assert(to.appliedLoyalties.contains(cashInLoyalty))
+        }
+
+        it("should be able to receive loyalties on an Unblocked state") {
+            val cashInLoyalty = LoyaltyGift(
+                "Discount Loyalty",
+                DiscountGiftStrategy(10),
+                10,
+                100,
+                LocalDate.now(),
+                LocalDate.MAX
+            )
+
+            to.setBlocked()
+
+            assert(to.isBlocked)
+            assertThrows<BlockedAccountException> { to.addLoyalty(cashInLoyalty) }
+        }
+    }
+})

--- a/src/test/kotlin/wallet/AccountSpec.kt
+++ b/src/test/kotlin/wallet/AccountSpec.kt
@@ -33,7 +33,7 @@ object AccountSpec : Spek({
             val from = AccountBuilder().user(anotherUser).build()
             val cashInTransfer = CashInTransfer(LocalDateTime.now(), amount, from, to )
 
-            to.setUnblocked()
+            to.unblock()
             to.addTransaction(cashInTransfer)
 
             assert(!to.isBlocked)
@@ -46,7 +46,7 @@ object AccountSpec : Spek({
             val from = AccountBuilder().user(anotherUser).build()
             val cashInTransfer = CashInTransfer(LocalDateTime.now(), amount, from, to )
 
-            to.setBlocked()
+            to.block()
 
             assert(to.isBlocked)
             assertThrows<BlockedAccountException> { to.addTransaction(cashInTransfer) }
@@ -62,7 +62,7 @@ object AccountSpec : Spek({
                 LocalDate.MAX
             )
 
-            to.setUnblocked()
+            to.unblock()
             to.addLoyalty(cashInLoyalty)
 
             assert(!to.isBlocked)
@@ -79,7 +79,7 @@ object AccountSpec : Spek({
                 LocalDate.MAX
             )
 
-            to.setBlocked()
+            to.block()
 
             assert(to.isBlocked)
             assertThrows<BlockedAccountException> { to.addLoyalty(cashInLoyalty) }

--- a/src/test/kotlin/wallet/DigitalWalletSpec.kt
+++ b/src/test/kotlin/wallet/DigitalWalletSpec.kt
@@ -268,7 +268,7 @@ object DigitalWalletSpec : Spek({
         }
 
         it("a wallet can't add gift to a blocked account") {
-            accountFrom.setBlocked()
+            accountFrom.block()
 
             assertThrows<BlockedAccountException> {
                 wallet.addGift(DigitalWallet.createGift(accountFrom, 200.0))
@@ -280,7 +280,7 @@ object DigitalWalletSpec : Spek({
             val account = wallet.accountByCVU("00001111")
             assertEquals(200.0, account.balance)
 
-            account.setBlocked()
+            account.block()
 
             assertThrows<BlockedAccountException> {
                 wallet.transferMoneyFromCard("00001111", creditCard, 100.0)

--- a/src/test/kotlin/wallet/DigitalWalletSpec.kt
+++ b/src/test/kotlin/wallet/DigitalWalletSpec.kt
@@ -102,7 +102,7 @@ object DigitalWalletSpec : Spek({
                 assertThrows<AssertionError> { wallet.assignAccount(user, account) }
             }
 
-            it("user should be register and then assign an account") {
+            it("user should be registered and then assign an account") {
                 val account = Account(user, cvu)
 
                 assertEquals(0, wallet.accounts.size)
@@ -112,7 +112,7 @@ object DigitalWalletSpec : Spek({
                 assertEquals(account, wallet.accounts.first())
                 assertEquals(account, wallet.users.first().account)
             }
-            it("when user is assigned to an account it recibes $200 as a gift") {
+            it("when user is assigned to an account it receives $200 as a gift") {
                 val account = Account(user, cvu)
                 wallet.register(user)
                 wallet.assignAccount(user, account)
@@ -122,6 +122,33 @@ object DigitalWalletSpec : Spek({
                 wallet.addGift(DigitalWallet.createGift(account, 200.0))
                 assertEquals(200.0, wallet.users.first().account!!.balance)
                 assertEquals(1, wallet.users.first().account!!.transactions.size)
+            }
+        }
+
+        context("Account manipulation") {
+            val cvu by memoized { DigitalWallet.generateNewCVU() }
+            val user by memoized { UserBuilder().idCard("11.222.333").build()  }
+
+            it("an account can be blocked") {
+                val account = Account(user, cvu)
+                wallet.register(user)
+                wallet.assignAccount(user, account)
+
+                wallet.blockAccount(account)
+
+                assert(account.isBlocked)
+            }
+
+
+            it("an account can be unblocked") {
+                val account = Account(user, cvu)
+                wallet.register(user)
+                wallet.assignAccount(user, account)
+
+                wallet.blockAccount(account)
+                wallet.unblockAccount(account)
+
+                assert(!account.isBlocked)
             }
         }
     }
@@ -172,6 +199,92 @@ object DigitalWalletSpec : Spek({
             assertEquals(200.0, wallet.accountByCVU("00001111").balance)
             wallet.transferMoneyFromCard("00001111", creditCard, 100.0)
             assertEquals(300.0, wallet.accountByCVU("00001111").balance)
+        }
+
+        it("a wallet can make transfers from an unblocked account to an unblocked account") {
+            val transfer = DigitalWallet.createCashTransfer(150.0, accountFrom, accountTo)
+
+            assertEquals(200.0, wallet.accountByCVU(accountFrom.cvu).balance)
+            assertEquals(200.0, wallet.accountByCVU(accountTo.cvu).balance)
+
+            wallet.unblockAccount(accountFrom)
+            wallet.unblockAccount(accountTo)
+
+            wallet.makeTransfer(
+                transfer["cashOut"] as CashOutTransfer,
+                transfer["cashIn"] as CashInTransfer
+            )
+        }
+
+        it("a wallet can't make transfers from an unblocked account to an blocked account") {
+            val transfer = DigitalWallet.createCashTransfer(150.0, accountFrom, accountTo)
+
+            assertEquals(200.0, wallet.accountByCVU(accountFrom.cvu).balance)
+            assertEquals(200.0, wallet.accountByCVU(accountTo.cvu).balance)
+
+            wallet.unblockAccount(accountFrom)
+            wallet.blockAccount(accountTo)
+
+            assertThrows<BlockedAccountException> {
+                wallet.makeTransfer(
+                    transfer["cashOut"] as CashOutTransfer,
+                    transfer["cashIn"] as CashInTransfer
+                )
+            }
+        }
+
+        it("a wallet can't make transfers from a blocked account to an unblocked account") {
+            val transfer = DigitalWallet.createCashTransfer(150.0, accountFrom, accountTo)
+
+            assertEquals(200.0, wallet.accountByCVU(accountFrom.cvu).balance)
+            assertEquals(200.0, wallet.accountByCVU(accountTo.cvu).balance)
+
+            wallet.blockAccount(accountFrom)
+            wallet.unblockAccount(accountTo)
+
+            assertThrows<BlockedAccountException> {
+                wallet.makeTransfer(
+                    transfer["cashOut"] as CashOutTransfer,
+                    transfer["cashIn"] as CashInTransfer
+                )
+            }
+        }
+
+        it("a wallet can't make transfers from an unblocked account to an unblocked account") {
+            val transfer = DigitalWallet.createCashTransfer(150.0, accountFrom, accountTo)
+
+            assertEquals(200.0, wallet.accountByCVU(accountFrom.cvu).balance)
+            assertEquals(200.0, wallet.accountByCVU(accountTo.cvu).balance)
+
+            wallet.blockAccount(accountFrom)
+            wallet.blockAccount(accountTo)
+
+            assertThrows<BlockedAccountException> {
+                wallet.makeTransfer(
+                    transfer["cashOut"] as CashOutTransfer,
+                    transfer["cashIn"] as CashInTransfer
+                )
+            }
+        }
+
+        it("a wallet can't add gift to a blocked account") {
+            accountFrom.setBlocked()
+
+            assertThrows<BlockedAccountException> {
+                wallet.addGift(DigitalWallet.createGift(accountFrom, 200.0))
+            }
+        }
+
+        it("a wallet can't transfer money from card to a blocked account") {
+            val creditCard = CreditCard("1111 1111 1111 1111", "fullName", LocalDate.now(), "1234")
+            val account = wallet.accountByCVU("00001111")
+            assertEquals(200.0, account.balance)
+
+            account.setBlocked()
+
+            assertThrows<BlockedAccountException> {
+                wallet.transferMoneyFromCard("00001111", creditCard, 100.0)
+            }
         }
     }
 })


### PR DESCRIPTION
Este PR contiene funcionalidad para blockear/desbloquear cuentas:

**Accounts:**
+   se agregan estados de bloqueo y desbloqueo que actúan como interceptores en `addLoyalty` y `addTransaction`
+   se agrega una exception para estados de cuenta bloqueada
+   ***uno de los estados se encarga de lanzar éstas exceptions*** *
+   se implementan tests unitarios para `Account`

**DigitalWallet:**
+   se implementan dos métodos `blockAccount` y `unblockAccount`, para bloquear y desbloquear cuentas, respectivamente.
+   se agregan guardas para aseverar que las cuentas no están bloqueadas, ante una transferencia y regalo.
+   se implementan test unitarios para transferencias y regalos durante un estado bloqueante

* **Importante:** las exceptions están repetidas... `Account` tiene la responsabilidad de lanzarlas durante una transferencia si alguna de las cuentas está en un estado bloqueante. Sin embargo, me doy cuenta que durante una transferencia en `DigitalWallet` podrían haber existido escenarios donde la primer cuenta `from` no está bloqueada, pero la segunda `to` si, entonces la exception se lanza luego de haber debitado un monto de `from`. Es por eso que `DigitalWallet` se está encargando de lanzar algunas exceptions.

¿Cómo podríamos mover ésta responabilidad a un solo lugar? Account dejaría de lanzarlas y solamente se ocuparía de gestionar el estado que le corresponde?
Tampoco me cerró del todo utilizar **isBlocked** como variable de instancia para denotar un estado. ¿Ideas? 

Creo que más o menos la idea está, habría que pulirlo un poco con lo que se nos vaya ocurriendo.

Closes #2

> edit: adds issue hook keyword